### PR TITLE
Add requirements text file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+asgiref==3.7.2
+Django==5.0
+django-admin-sortable2==2.1.10
+django-environ==0.11.2
+sqlparse==0.4.4
+tzdata==2023.3


### PR DESCRIPTION
The requirements.txt file can be easily used to install add needed packages to run the app by calling: 

pip install -r requirements.txt
